### PR TITLE
Make it work in private browsing

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -6,9 +6,9 @@ const {Cc,Ci,Cr,Cu} = require("chrome");
 
 Cu.import("resource://services-sync/main.js");
 
-const contextMenu = require("context-menu");
-const tabs        = require("tabs");
-const xulApp      = require("xul-app");
+const contextMenu = require("sdk/context-menu");
+const tabs        = require("sdk/tabs");
+const xulApp      = require("sdk/system/xul-app");
 
 function promptAndSendURIToDevice(uri, title) {
   let clientsEngine = Weave.Service.clientsEngine || // for Firefox 19+

--- a/package.json
+++ b/package.json
@@ -5,5 +5,6 @@
     "version": "0.6",
     "fullName": "Send Tab to Device",
     "id": "jid1-mdjmA7if6lo8lA",
-    "description": "Send a tab or link to another device using Firefox Sync"
+    "description": "Send a tab or link to another device using Firefox Sync",
+    "permissions": {"private-browsing": true}
 }


### PR DESCRIPTION
I added the private browsing permission to make it work in private browsing as well. I also fixed some simple errors by prepending the requires in main.js with `sdk/`.