### PR TITLE
Extension should prompt if services.sync.enabled=false. This is neces…

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -9,13 +9,16 @@ Cu.import("resource://services-sync/main.js");
 const contextMenu = require("sdk/context-menu");
 const tabs        = require("sdk/tabs");
 const xulApp      = require("sdk/system/xul-app");
+const prefs       = require("sdk/preferences/service");
+const simplePrefs = require("sdk/simple-prefs").prefs;
+
+let promptService = Cc["@mozilla.org/embedcomp/prompt-service;1"]
+                    .getService(Ci.nsIPromptService);
 
 function promptAndSendURIToDevice(uri, title) {
   let clientsEngine = Weave.Service.clientsEngine || // for Firefox 19+
                       Weave.Clients;                 // for Firefox up-to 18
   let remoteClients = clientsEngine._store._remoteClients;
-  let promptService = Cc["@mozilla.org/embedcomp/prompt-service;1"]
-                      .getService(Ci.nsIPromptService);
 
   // get a list of the remote client name and its id.
   let labels = [];
@@ -102,6 +105,30 @@ exports.main = function main(options, callbacks) {
                  "Installing handler.");
     handleReceived = true;
     Svc.Obs.add("weave:engine:clients:display-uri", handleDisplayURI);
+  }
+
+  let checkSyncEnabledPref = "checkSyncEnabled";
+  let syncEnabledPref = "services.sync.enabled";
+  if (simplePrefs[checkSyncEnabledPref] && !prefs.get(syncEnabledPref, false)) {
+    let dialogTitle = "Send Tab to Device extension";
+    let promptText = "Firefox Sync is currently disabled, but " +
+                     "the Send Tab to Device extension can't work without " +
+                     "Firefox Sync.\n" +
+                     "Do you want to enable Firefox Sync?";
+    let checkboxText = "Don't remind me again";
+    let checkboxState = { value: false };
+    let buttonFlags = Ci.nsIPromptService.STD_YES_NO_BUTTONS;
+    let userChoice = promptService.confirmEx(null, dialogTitle, promptText,
+                                             buttonFlags, "", "", "",
+                                             checkboxText, checkboxState);
+    if (userChoice == 0) {
+      // User chose to re-enable Firefox sync
+      prefs.set(syncEnabledPref, true);
+    }
+    if (checkboxState.value) {
+      // User wants to suppress this prompt
+      simplePrefs[checkSyncEnabledPref] = false;
+    }
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -2,10 +2,17 @@
     "name": "send-tab-to-device",
     "license": "MPL 2.0",
     "author": "Gregory Szorc <gps@mozilla.com>",
-    "version": "0.7.1",
+    "version": "0.7.2",
     "title": "Send Tab to Device",
     "id": "jid1-mdjmA7if6lo8lA@jetpack",
     "description": "Send a tab or link to another device using Firefox Sync",
     "main": "./lib/main",
-    "permissions": {"private-browsing": true}
+    "permissions": {"private-browsing": true},
+    "preferences": [{
+      "name": "checkSyncEnabled",
+      "title": "Warn me if Firefox Sync is off",
+      "description": "Warn me during Firefox startup if the Sync service is off",
+      "type": "bool",
+      "value": true
+    }]
 }


### PR DESCRIPTION
…sary because of a recent change in Firefox Sync behaviour: if the user hasn't opted into syncing anything (history, addons, prefs, etc), then Firefox will change services.sync.enabled to false
