### PR TITLE
Clarify that this addon is now obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@ This is the addon-sendtab add-on.  It contains:
 * A program (lib/main.js).
 * A few tests.
 * Some meager documentation.
+
+## Now Obsolete
+
+This addon has been superseded by the [Synced
+Tabs](https://wiki.mozilla.org/QA/Synced_Tabs) feature of Firefox Sync (since
+[bug 677372](https://bugzilla.mozilla.org/show_bug.cgi?id=677372) was fixed in
+Firefox 50).  A tab can be sent to a device by enabling "Open Tabs" in the
+"Sync Across All Devices" section of the "Sync" preferences, then
+right-clicking on the tab to send and choosing the "Send Tab to Device"
+option.


### PR DESCRIPTION
As best I can tell, the functionality from this addon is now built-in to Firefox as part of the Synchronized Tabs feature of Firefox Sync and that there is no further use for this addon.  As a former user, this was not clear to me and took some investigating.  This PR adds a note to explain this in the README to clarify the upgrade path for existing users and discourage new users from installing this addon.

I would suggest updating the description in addons.mozilla.org to clarify this as well.

Thanks,
Kevin